### PR TITLE
Correctly deactivates the plugin if Give not active.

### DIFF
--- a/includes/give-email-reports-activation.php
+++ b/includes/give-email-reports-activation.php
@@ -31,7 +31,7 @@ function give_email_reports_activation_banner() {
 		add_action( 'admin_notices', 'give_email_reports_activation_notice' );
 
 		//Don't let this plugin activate
-		deactivate_plugins( plugin_basename( __FILE__ ) );
+		deactivate_plugins( plugin_basename( GIVE_EMAIL_REPORTS_BASENAME ) );
 
 		if ( isset( $_GET['activate'] ) ) {
 			unset( $_GET['activate'] );


### PR DESCRIPTION
I discovered that `( __File__ )` is pointing to this file, so while the plugin doesn't fully activate and throw a fatal error, by not correctly pointing to the actual basename, it is not deactivated. This fixes it. 