### PR TITLE
fix(admin-donation): remove email report setting from donation email tab #48

### DIFF
--- a/includes/emails/class-daily-report-email.php
+++ b/includes/emails/class-daily-report-email.php
@@ -24,6 +24,7 @@ class Give_Daily_Email_Notification extends Give_Email_Notification {
 			'content_type'                 => 'text/html',
 			'email_template'               => 'default',
 			'has_recipient_field'          => true,
+			'form_metabox_setting'         => false,
 			'default_email_subject'        => sprintf( __( 'Daily Donation Report for %1$s', 'give-email-reports' ), get_bloginfo( 'name' ) ),
 		) );
 

--- a/includes/emails/class-monthly-report-email.php
+++ b/includes/emails/class-monthly-report-email.php
@@ -6,19 +6,20 @@
 class Give_Monthly_Email_Notification extends Give_Email_Notification {
 	function init() {
 		$this->load( array(
-			'id'                    => 'monthly-report',
-			'label'                 => __( 'Monthly Email Report', 'give-email-reports' ),
-			'description'           => __( '', 'give-email-reports' ),
-			'notification_status'   => 'disabled',
+			'id'                           => 'monthly-report',
+			'label'                        => __( 'Monthly Email Report', 'give-email-reports' ),
+			'description'                  => __( '', 'give-email-reports' ),
+			'notification_status'          => 'disabled',
 			'notification_status_editable' => array(
 				'list_mode' => false,
 			),
-			'content_type_editable' => false,
-			'has_preview_header'    => false,
-			'content_type'          => 'text/html',
-			'email_template'        => 'default',
-			'has_recipient_field'   => true,
-			'default_email_subject' => sprintf( __( 'Monthly Donation Report for %1$s', 'give-email-reports' ), get_bloginfo( 'name' ) ),
+			'content_type_editable'        => false,
+			'has_preview_header'           => false,
+			'content_type'                 => 'text/html',
+			'email_template'               => 'default',
+			'has_recipient_field'          => true,
+			'form_metabox_setting'         => false,
+			'default_email_subject'        => sprintf( __( 'Monthly Donation Report for %1$s', 'give-email-reports' ), get_bloginfo( 'name' ) ),
 		) );
 
 		add_filter( 'give_email_notification_setting_fields', array( $this, 'unset_email_setting_field' ), 10, 2 );

--- a/includes/emails/class-weekly-report-email.php
+++ b/includes/emails/class-weekly-report-email.php
@@ -6,19 +6,20 @@
 class Give_Weekly_Email_Notification extends Give_Email_Notification {
 	function init() {
 		$this->load( array(
-			'id'                    => 'weekly-report',
-			'label'                 => __( 'Weekly Email Report', 'give-email-reports' ),
-			'description'           => __( '', 'give-email-reports' ),
-			'notification_status'   => 'disabled',
+			'id'                           => 'weekly-report',
+			'label'                        => __( 'Weekly Email Report', 'give-email-reports' ),
+			'description'                  => __( '', 'give-email-reports' ),
+			'notification_status'          => 'disabled',
 			'notification_status_editable' => array(
 				'list_mode' => false,
 			),
-			'content_type_editable' => false,
-			'has_preview_header'    => false,
-			'content_type'          => 'text/html',
-			'email_template'        => 'default',
-			'has_recipient_field'   => true,
-			'default_email_subject' => sprintf( __( 'Weekly Donation Report for %1$s', 'give-email-reports' ), get_bloginfo( 'name' ) ),
+			'content_type_editable'        => false,
+			'has_preview_header'           => false,
+			'content_type'                 => 'text/html',
+			'email_template'               => 'default',
+			'has_recipient_field'          => true,
+			'form_metabox_setting'         => false,
+			'default_email_subject'        => sprintf( __( 'Weekly Donation Report for %1$s', 'give-email-reports' ), get_bloginfo( 'name' ) ),
 		) );
 
 		add_filter( 'give_email_notification_setting_fields', array( $this, 'unset_email_setting_field' ), 10, 2 );


### PR DESCRIPTION
## Description
PR to fix #48 

## How Has This Been Tested?
Manually tested by removing the Email report setting from perform basic 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/37817919-7a785c86-2e9e-11e8-82db-3d77ab0f6116.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.